### PR TITLE
feat(core/http): implement HTTP infrastructure and error normalization

### DIFF
--- a/src/app/core/http/README.md
+++ b/src/app/core/http/README.md
@@ -1,0 +1,314 @@
+# HTTP Layer (core/http)
+
+Purpose: centralize HTTP behavior for the frontend so services remain small and consistent.
+
+Files:
+
+```
+api-client.ts
+api-error.model.ts
+error.util.ts
+```
+
+---
+
+# Role in Application Architecture
+
+Request flow:
+
+```
+Component
+   ↓
+Feature Service
+   ↓
+ApiClient
+   ↓
+Angular HttpClient
+   ↓
+Backend API
+```
+
+Responsibilities by layer
+
+| Layer           | Responsibility                        |
+| --------------- | ------------------------------------- |
+| Component       | UI logic, user interaction            |
+| Feature Service | Map API endpoints to functions        |
+| ApiClient       | HTTP requests + error normalization   |
+| HttpClient      | Angular low‑level HTTP implementation |
+
+Rule:
+
+```
+Components and feature services must NOT use HttpClient directly
+```
+
+All HTTP calls pass through **ApiClient**.
+
+---
+
+# Why ApiClient Exists
+
+Without wrapper:
+
+```ts
+this.http.post(`${BASE_API_URL}/jobs`, body)
+```
+
+With wrapper:
+
+```ts
+this.api.post<Job>('/jobs', dto)
+```
+
+Benefits:
+
+| Problem                 | Solution                 |
+| ----------------------- | ------------------------ |
+| repeated base URL       | centralized in ApiClient |
+| repeated error handling | normalized once          |
+| duplicated HTTP logic   | removed from services    |
+
+---
+
+# File Overview
+
+## api-client.ts
+
+HTTP wrapper around Angular `HttpClient`.
+
+Methods provided:
+
+```
+get<T>()
+post<T>()
+patch<T>()
+delete<T>()
+```
+
+Example service usage:
+
+```ts
+return this.api.get<User>('/users/me')
+```
+
+Generic `<T>` represents expected response type.
+
+---
+
+## api-error.model.ts
+
+Standardized error structure used across the frontend.
+
+Type:
+
+```
+ApiError
+```
+
+Fields:
+
+| Field   | Meaning                        |
+| ------- | ------------------------------ |
+| status  | HTTP status code               |
+| message | readable backend error message |
+| raw     | original backend payload       |
+
+Purpose:
+
+```
+Avoid exposing Angular HttpErrorResponse objects to UI components
+```
+
+---
+
+## error.util.ts
+
+Utility that converts Angular errors into `ApiError`.
+
+Backend error format:
+
+```
+{ "error": "message" }
+```
+
+Transformation:
+
+```
+HttpErrorResponse
+   ↓
+normalizeError()
+   ↓
+ApiError
+```
+
+---
+
+# Angular HTTP Behavior
+
+Angular HTTP calls return **Observables**, not Promises.
+
+Example:
+
+```ts
+http.get<User>()
+```
+
+returns
+
+```
+Observable<User>
+```
+
+Meaning:
+
+```
+a future asynchronous value that will emit a User
+```
+
+---
+
+# Observables (Quick Reference)
+
+Concept summary:
+
+| Property   | Explanation                       |
+| ---------- | --------------------------------- |
+| lazy       | request runs only when subscribed |
+| cancelable | subscription can be cancelled     |
+| composable | operators transform the stream    |
+
+Example:
+
+```ts
+this.service.method().subscribe({
+  next: data => ...
+  error: err => ...
+})
+```
+
+Handlers:
+
+| Handler  | Purpose             |
+| -------- | ------------------- |
+| next     | successful response |
+| error    | failure response    |
+| complete | stream finished     |
+
+HTTP calls usually use only **next** and **error**.
+
+---
+
+# RxJS Operator Used
+
+Operator used in ApiClient:
+
+```
+catchError()
+```
+
+Purpose:
+
+```
+Intercept errors in observable pipeline
+```
+
+Flow:
+
+```
+HTTP error
+   ↓
+catchError
+   ↓
+normalizeError()
+   ↓
+ApiError
+```
+
+Result:
+
+```
+UI always receives ApiError
+```
+
+---
+
+# Example Usage
+
+Service:
+
+```ts
+createJob(dto: JobCreateDTO) {
+  return this.api.post<Job>('/jobs', dto)
+}
+```
+
+Component:
+
+```ts
+this.jobsService.createJob(dto).subscribe({
+  next: job => ...,
+  error: err => this.errorMessage = err.message
+})
+```
+
+### Typical Component Pattern example:
+```ts
+submit() {
+
+  this.loading = true
+  this.errorMessage = null
+
+  this.service.call(dto).subscribe({
+
+    next: result => {
+      this.loading = false
+      ...
+    },
+
+    error: err => {
+      this.loading = false
+      this.errorMessage = err.message
+    }
+
+  })
+}
+```
+---
+
+# Design Rules
+
+| Rule                        | Reason                       |
+| --------------------------- | ---------------------------- |
+| HTTP logic centralized      | avoid duplication            |
+| services remain thin        | easier maintenance           |
+| consistent error structure  | simpler UI handling          |
+| components focus on UI only | clear separation of concerns |
+
+---
+
+# Documentation Sources
+
+Angular HttpClient
+
+[https://angular.dev/guide/http](https://angular.dev/guide/http)
+
+RxJS Observables
+
+[https://rxjs.dev/guide/observable](https://rxjs.dev/guide/observable)
+
+RxJS catchError
+
+[https://rxjs.dev/api/operators/catchError](https://rxjs.dev/api/operators/catchError)
+
+Angular Error Handling (HttpErrorResponse)
+
+[https://angular.dev/api/common/http/HttpErrorResponse](https://angular.dev/api/common/http/HttpErrorResponse)
+
+Reactive Programming Concepts
+
+[https://rxjs.dev/guide/overview](https://rxjs.dev/guide/overview)
+
+---
+
+End of HTTP layer documentation.

--- a/src/app/core/http/api-client.ts
+++ b/src/app/core/http/api-client.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@angular/core'
+import { HttpClient, HttpErrorResponse } from '@angular/common/http'
+import { Observable, catchError, throwError } from 'rxjs'
+
+import { BASE_API_URL } from '../config/api.config'
+import { normalizeError } from './error.util'
+
+/**
+ * ApiClient
+ *
+ * Purpose
+ * -------
+ * Centralized HTTP wrapper used by all domain services.
+ *
+ * Motivation
+ * ----------
+ * Without this wrapper each service would need to:
+ *
+ * - prepend the API base URL
+ * - handle HttpErrorResponse
+ * - normalize backend error payloads
+ *
+ * Centralizing this logic guarantees consistent behaviour across the
+ * application and prevents duplication.
+ *
+ * Architectural Flow
+ *
+ * Component
+ *   ↓
+ * Feature Service (jobs.service, auth.service, etc)
+ *   ↓
+ * ApiClient
+ *   ↓
+ * Angular HttpClient
+ *   ↓
+ * Backend API
+ *
+ * Responsibilities
+ * ----------------
+ * 1. Automatically prefix the API base URL
+ * 2. Provide typed HTTP helpers
+ * 3. Normalize backend errors into ApiError objects
+ *
+ * Services must NEVER use HttpClient directly.
+ */
+@Injectable({ providedIn: 'root' })
+export class ApiClient {
+
+  constructor(private readonly http: HttpClient) {}
+
+  /**
+   * GET request helper.
+   *
+   * Example usage inside a service:
+   *
+   *   return this.api.get<User>('/users/me')
+   */
+  get<T>(path: string): Observable<T> {
+    return this.http
+      .get<T>(`${BASE_API_URL}${path}`)
+      .pipe(catchError(this.handleError))
+  }
+
+  /**
+   * POST request helper.
+   *
+   * Example usage:
+   *
+   *   return this.api.post<Job>('/jobs', dto)
+   */
+  post<T>(path: string, body: unknown): Observable<T> {
+    return this.http
+      .post<T>(`${BASE_API_URL}${path}`, body)
+      .pipe(catchError(this.handleError))
+  }
+
+  /**
+   * PATCH request helper.
+   */
+  patch<T>(path: string, body: unknown): Observable<T> {
+    return this.http
+      .patch<T>(`${BASE_API_URL}${path}`, body)
+      .pipe(catchError(this.handleError))
+  }
+
+  /**
+   * DELETE request helper.
+   */
+  delete<T>(path: string): Observable<T> {
+    return this.http
+      .delete<T>(`${BASE_API_URL}${path}`)
+      .pipe(catchError(this.handleError))
+  }
+
+  /**
+   * Error handler used by all requests.
+   *
+   * RxJS catchError requires returning an Observable.
+   * throwError creates an observable that emits the normalized ApiError.
+   */
+  private handleError(error: HttpErrorResponse) {
+    return throwError(() => normalizeError(error))
+  }
+}

--- a/src/app/core/http/api-error.model.ts
+++ b/src/app/core/http/api-error.model.ts
@@ -1,0 +1,28 @@
+/**
+ * ApiError
+ *
+ * Standard error structure used throughout the frontend.
+ *
+ * Angular's HttpClient throws HttpErrorResponse objects whose structure
+ * varies depending on the failure source (backend error, network failure,
+ * parsing error, etc).
+ *
+ * This type defines a simplified and predictable error shape that UI
+ * components can safely consume.
+ *
+ * Properties
+ * ----------
+ * status
+ *   HTTP status code returned by the backend.
+ *
+ * message
+ *   Human-readable error message extracted from the backend response.
+ *
+ * raw
+ *   Original backend payload preserved for debugging or inspection.
+ */
+export type ApiError = {
+  status: number
+  message: string
+  raw?: unknown
+}

--- a/src/app/core/http/error.util.ts
+++ b/src/app/core/http/error.util.ts
@@ -1,0 +1,51 @@
+import { HttpErrorResponse } from '@angular/common/http'
+import { ApiError } from './api-error.model'
+
+/**
+ * normalizeError
+ *
+ * Purpose
+ * -------
+ * Converts Angular HttpErrorResponse objects into the application's
+ * standardized ApiError structure.
+ *
+ * The SkillSwap backend returns errors using the format:
+ *
+ *   { "error": "message" }
+ *
+ * Angular wraps this response inside HttpErrorResponse, which may contain
+ * different structures depending on the failure scenario.
+ *
+ * This function safely extracts the backend message while providing a
+ * fallback message if the expected structure is not present.
+ *
+ * Example transformation
+ *
+ * Backend response:
+ *   HTTP 400
+ *   { "error": "Missing required fields" }
+ *
+ * Result:
+ *   {
+ *     status: 400,
+ *     message: "Missing required fields"
+ *   }
+ */
+export function normalizeError(error: HttpErrorResponse): ApiError {
+
+  let message = 'Unexpected error'
+
+  if (
+    error.error &&
+    typeof error.error === 'object' &&
+    'error' in error.error
+  ) {
+    message = error.error.error
+  }
+
+  return {
+    status: error.status,
+    message,
+    raw: error.error
+  }
+}


### PR DESCRIPTION
- add ApiClient wrapper for HttpClient (get/post/patch/delete)
- centralize API base URL usage
- implement ApiError type for standardized error handling
- add normalizeError utility to convert HttpErrorResponse → ApiError
- integrate RxJS catchError + throwError in ApiClient
- add HTTP layer README documenting architecture, observables, and usage